### PR TITLE
Fix group premisssions for git cache init

### DIFF
--- a/git-cache
+++ b/git-cache
@@ -31,9 +31,7 @@ then
     [ "$CACHE" = "" ] && CACHE=~/.cache/git-cache
     mkdir -p "$CACHE"
     cd "$CACHE"
-    git init --bare
-    chgrp -R users .
-    chmod -R g+w .
+    git init --bare --shared=group
     git config --$TYPE cache.directory "$CACHE"
     
 # Trigger 'delete' action


### PR DESCRIPTION
The 'users' group is not guaranteed to exist, use git functionality to add
group permissions instead.

(git cache init failed ni git bash on windows since there is no 'users' group there)